### PR TITLE
Create <fluent-provider>

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -116,6 +116,27 @@ If the error is due to the message not being found, you'll get
 }
 ```
 
+# Provider
+
+Assigning bundles to large numbers of elements can sometimes be inconvenient. `fluent-provider` can do this for you: set only the provider's bundles, and the provider will keep its children up to date.
+
+```html
+<!-- index.html -->
+<fluent-provider>
+  <fluent-text messageId="hello"></fluent-text>
+  <fluent-element messageId="name">
+    <input type="text" />
+  </fluent-element>
+</fluent-provider>
+```
+
+```js
+// index.js
+document.getElementsByTagName("fluent-provider")[0].bundles = yourBundles;
+```
+
+Bundles assigned to a single element will take priority over those assigned by a provider.
+
 # Framework Support
 
 The great thing about fluent-web being a web component is that we can use it in any front end framework or language that supports web components. The [demo](https://wolfadex.github.io/fluent-web/) is written in [Elm](https://elm-lang.org/), and there are additional [examples](https://github.com/wolfadex/fluent-web/tree/master/example) built in [Svelte](https://svelte.dev/) and vanilla html & javascript.

--- a/example/elm/Example.elm
+++ b/example/elm/Example.elm
@@ -375,4 +375,20 @@ view model =
                 )
                 allFruit
             )
+        , Html.br [] []
+        , Html.br [] []
+        , Html.text "Provider-based messages:"
+        , Html.br [] []
+        , Html.node "fluent-provider"
+            [ bundless ]
+            [ Html.node "fluent-text"
+                [ Html.Attributes.attribute "messageId" "hello-no-name"
+                ]
+                []
+            , Html.br [] []
+            , Html.node "fluent-text"
+                [ Html.Attributes.attribute "messageId" "sign-in-or-cancel"
+                ]
+                []
+            ]
         ]

--- a/example/svelte/src/App.svelte
+++ b/example/svelte/src/App.svelte
@@ -1,4 +1,5 @@
 <script>
+  export let resources;
   import { negotiateLanguages } from '@fluent/langneg';
   import { FluentBundle, FluentResource } from '@fluent/bundle';
 
@@ -119,4 +120,13 @@
       {/each}
     </select>
   </label>
+  <br />
+  <br />
+  Provider-based messages:
+  <br />
+  <fluent-provider bundles={currentBundles}>
+    <fluent-text messageId="hello-no-name"></fluent-text>
+    <br />
+    <fluent-text messageId="sign-in-or-cancel"></fluent-text>
+  </fluent-provider>
 </main>

--- a/example/vanillajs/index.html
+++ b/example/vanillajs/index.html
@@ -52,6 +52,15 @@
         ></fluent-text>
         <select id="favoriteFruitSelect"></select>
       </label>
+      <br />
+      <br />
+      Provider-based messages:
+      <br />
+      <fluent-provider>
+        <fluent-text messageId="hello-no-name"></fluent-text>
+        <br />
+        <fluent-text messageId="sign-in-or-cancel"></fluent-text>
+      </fluent-provider>
     </main>
 
     <script src="index.js"></script>

--- a/example/vanillajs/index.js
+++ b/example/vanillajs/index.js
@@ -45,6 +45,7 @@ const elHelloNoName = document.getElementById("helloNoName");
 const elSignInOrCancel = document.getElementById("signInOrCancel");
 const elTodayDate = document.getElementById("todayDate");
 const elPersonNameInput = document.getElementById("personNameInput");
+const elProvider = document.getElementsByTagName("fluent-provider")[0];
 let personName = "Carl";
 
 elPersonNameInput.value = "Carl";
@@ -106,6 +107,8 @@ function updateLocalization() {
 
   elFavoriteFruitLabel.bundles = bundles;
   elFruitList.map((el) => (el.bundles = bundles));
+
+  elProvider.bundles = bundles;
 }
 
 updateLocalization();

--- a/src/index.js
+++ b/src/index.js
@@ -56,17 +56,21 @@ class FluentElement extends HTMLElement {
   }
 
   connectedCallback() {
-    this.dispatchEvent(new CustomEvent('fluent-bundles-subscribe', {
-      bubbles: true,
-      target: this,
-    }));
+    this.dispatchEvent(
+      new CustomEvent("fluent-bundles-subscribe", {
+        bubbles: true,
+        target: this,
+      })
+    );
     this.render();
   }
   disconnectedCallback() {
-    this.dispatchEvent(new CustomEvent('fluent-bundles-unsubscribe', {
-      bubbles: true,
-      target: this,
-    }));
+    this.dispatchEvent(
+      new CustomEvent("fluent-bundles-unsubscribe", {
+        bubbles: true,
+        target: this,
+      })
+    );
   }
 
   set providerBundles(newBundles) {
@@ -104,29 +108,29 @@ class FluentProvider extends HTMLElement {
   constructor() {
     super();
     this._listeners = [];
-    this.addEventListener('fluent-bundles-subscribe', event => {
+    this.addEventListener("fluent-bundles-subscribe", (event) => {
       this._listeners.push(event.target);
       if (this._bundles) {
         event.target.providerBundles = this._bundles;
       }
-    })
-    this.addEventListener('fluent-bundles-unsubscribe', event => {
+    });
+    this.addEventListener("fluent-bundles-unsubscribe", (event) => {
       const i = this._listeners.findIndex(event.target);
       if (i >= 0) {
         this._listeners.splice(i, 1);
       }
-    })
+    });
   }
   get bundles() {
     return this._bundles;
   }
   set bundles(b) {
     this._bundles = b;
-    this._listeners.forEach(target => {
+    this._listeners.forEach((target) => {
       if (this._bundles) {
         target.providerBundles = this._bundles;
       }
-    })
+    });
   }
 }
 


### PR DESCRIPTION
Hello, and thank you for this project!

The Fluent-React bindings have [`LocalizationProvider`](https://github.com/projectfluent/fluent.js/wiki/React-Bindings#localizationprovider) - pass bundles to one place near the root of the page, instead of passing them to every translated element. I found myself wanting something similar for an Elm project using your components, so I wrote it.

Passing bundles to every `fluent-text`/`fluent-element` still works; this isn't a breaking change. If an element finds bundles from both sources, the provider's bundles are ignored.