### PR TITLE
Quieter formatting of blank messages

### DIFF
--- a/example/elm/example.js
+++ b/example/elm/example.js
@@ -26,6 +26,11 @@ function getBundles(desiredLocales) {
     return bundles;
 }
 
+// Log translation errors
+window.addEventListener("fluent-web-error", function(event) {
+  console.error(event);
+})
+
 const app = Elm.Example.init({
   node: document.getElementById("root"),
   flags: {

--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,9 @@ class FluentElement extends HTMLElement {
           const formatted = { value: null, attributes: {} };
           let errors = [];
 
-          // `formatPattern(null)` - blank messages - does work, but logs warnings
-          formatted.value = bundle.formatPattern(message.value || "", args, errors);
+          if (message.value) {
+            formatted.value = bundle.formatPattern(message.value, args, errors);
+          }
 
           Object.entries(message.attributes).forEach(([name, value]) => {
             if (whitelist.includes(name)) {

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,8 @@ class FluentElement extends HTMLElement {
           const formatted = { value: null, attributes: {} };
           let errors = [];
 
-          formatted.value = bundle.formatPattern(message.value, args, errors);
+          // `formatPattern(null)` - blank messages - does work, but logs warnings
+          formatted.value = bundle.formatPattern(message.value || "", args, errors);
 
           Object.entries(message.attributes).forEach(([name, value]) => {
             if (whitelist.includes(name)) {


### PR DESCRIPTION
Using a blank message like this currently logs an error from `bundle.formatPattern(null)`, but otherwise behaves fine:

```
hello =
  .title = mouseover text
```

```
<fluent-element messageId="hello"><div></div></fluent-element>
```

This change silences the error