### PR TITLE
import from cached-iterable/compat - legacy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { mapBundleSync } from "@fluent/sequence";
-import { CachedSyncIterable } from "cached-iterable";
+import { CachedSyncIterable } from "cached-iterable/compat";
 
 const MESSAGE_ID_ATTRIBUTE = "messageId";
 


### PR DESCRIPTION
To solve the following problem on legacy browsers:

node_modules/@wolfadex/fluent-web/src/index.js
Attempted import error: 'CachedSyncIterable' is not exported from 'cached-iterable'.

https://github.com/projectfluent/cached-iterable states to import from cached-iterable/compat using babel-polyfill;