### PR TITLE
adherence to Html attribute naming convention

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { mapBundleSync } from "@fluent/sequence";
 import { CachedSyncIterable } from "cached-iterable";
 
-const MESSAGE_ID_ATTRIBUTE = "messageId";
+const MESSAGE_ID_ATTRIBUTE = "message-id";
 
 class FluentElement extends HTMLElement {
   getMessage({ messageId, args, unsafeArgs, whitelist = [] }) {


### PR DESCRIPTION
I had troubles with the html attribute being named `messageId` as at least my code using elm ui would lowercase it to `messageid` in the dom. As a result `observedAttributes` and `attributeChangedCallback` were broken and no updates on messageId change happened. When changing the name to `message-id` the attributeChangedCallback works as expected. Lowercase and hyphenated attribute names also seem to be more [in line with common naming conventions](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes)