### PR TITLE
TH 🍋

### DIFF
--- a/example/common/resources.js
+++ b/example/common/resources.js
@@ -83,7 +83,7 @@ clicked-cancel = ไม่เป็นไร
 favorite-fruit = ผลไม้ที่ชอบ
 fruit-apple = แอปเปิ้ล
 fruit-orange = ส้ม
-fruit-lemon = มะนาว
+fruit-lemon = เลมอน
 `);
 
 const eo = new FluentResource(`


### PR DESCRIPTION
This is a tricky one sorta since lemon is [เลมอน](http://learn-thai.portalsbay.com/index.php?page=learnthai&id=15335&c=32&englishlanguage=lemon ), and while มะนาว is lime, it's often used as a stand-in for lemon as the distinction between the two isn't really made often. I think I could compare it to me saying basil is basil, but Thais always make the distinction between [Thai basil and holy basil](https://www.spiceography.com/thai-basil-vs-holy-basil/) (which doesn't include the sweet basil); I used to use Thai basil when cooking in the US since the Asian store sold whatever basil for cheaper than chain stores haha.  ชามะนาว is a lime tea, but is people often translate it to lemon tea. I'm just guessing since lemon tea is much more common in the West that's what the translations bots say and it's all over menus, but it's definitely lime-flavored. I usually try to ask if it's lemon or lime if I order off a menu, and people seem puzzled that I'd even ask (I could imagine the same look from a waitress if I asked what type of basil is this?). That said, I much prefer lime tea to lemon. /story

For reference [Google Translate of "Lemon. Lime."](https://translate.google.com/#view=home&op=translate&sl=auto&tl=th&text=Lemon.%20Lime.).

@turboMaCk